### PR TITLE
swap source and target, windows changes

### DIFF
--- a/implementation/org.gravity.eclipse/src/org/gravity/eclipse/importer/gradle/GradleBuild.java
+++ b/implementation/org.gravity.eclipse/src/org/gravity/eclipse/importer/gradle/GradleBuild.java
@@ -135,7 +135,7 @@ public class GradleBuild {
 		Process process = null;
 		switch (OperationSystem.os) {
 		case WINDOWS:
-			process = Runtime.getRuntime().exec(new String[] { "gradlew ", buildTarget }, null, path);
+			process = Runtime.getRuntime().exec(new String[] { "cmd", " /c \" gradlew " + buildTarget}, null, path);
 			break;
 		case LINUX:
 			process = Runtime.getRuntime().exec(new String[] { "./gradlew ", buildTarget }, null, path);

--- a/implementation/org.gravity.eclipse/src/org/gravity/eclipse/importer/gradle/GradleBuild.java
+++ b/implementation/org.gravity.eclipse/src/org/gravity/eclipse/importer/gradle/GradleBuild.java
@@ -82,7 +82,11 @@ public class GradleBuild {
 			gradlew = this.gradleBin;
 		}
 
-		FileUtils.changeToOSEncoding(gradlew);
+		try {
+			FileUtils.changeToOSEncoding(gradlew);
+		} catch (IOException e) {
+			LOGGER.warn("could not change gradlew to os specific line delimiters");
+		}
 		if (!gradlew.setExecutable(true)) {
 			return false;
 		}

--- a/implementation/org.gravity.eclipse/src/org/gravity/eclipse/importer/gradle/GradleImport.java
+++ b/implementation/org.gravity.eclipse/src/org/gravity/eclipse/importer/gradle/GradleImport.java
@@ -234,12 +234,12 @@ public class GradleImport extends ProjectImport {
 	private HashMap<String, Set<Path>> getSourceFolderMapping(final Set<Path> javaSourceFiles) {
 		final HashMap<String, Set<Path>> sourceFolders = new HashMap<>();
 		for (final Path sourceFile : javaSourceFiles) {
-			final Path path = getRootDir().toPath();
+			final Path path = getRootDir().getAbsoluteFile().toPath();
 			String relativize;
 			try {
 				relativize = path.relativize(sourceFile).toString();
 			} catch (final IllegalArgumentException e) {
-				relativize = sourceFile.toString().replaceFirst(new File("").getAbsolutePath(), "");
+				relativize = sourceFile.toString().replace(new File("").getAbsolutePath(), "");
 				final char charAt0 = relativize.charAt(0);
 				if (charAt0 == '/' || charAt0 == '\\') {
 					relativize = relativize.substring(1);

--- a/implementation/org.gravity.eclipse/src/org/gravity/eclipse/importer/gradle/GradleJavaFiles.java
+++ b/implementation/org.gravity.eclipse/src/org/gravity/eclipse/importer/gradle/GradleJavaFiles.java
@@ -59,7 +59,7 @@ public class GradleJavaFiles {
 	private Path manipuateBuildFile(Path build) throws IOException {
 		final Path backupLocation = Files.copy(build, Files.createTempFile("backupBuildGardle", ""),
 				StandardCopyOption.REPLACE_EXISTING);
-		final String taskCode = "\n" + "task " + BUILD_TARGET + " {\n" + "  def outputFile = file(\"" + this.output + "\")\n"
+		final String taskCode = "\n" + "task " + BUILD_TARGET + " {\n" + "  def outputFile = file(\"" + this.output.toString().replace("\\", "/") + "\")\n"
 				+ "  outputs.file  outputFile\n" + "  doLast {\n" + "    subprojects { project ->\n"
 				+ "      project.plugins.withType(JavaPlugin) {\n"
 				+ "        project.sourceSets.main.allJava.collect { sourceFile ->\n"

--- a/implementation/org.gravity.eclipse/src/org/gravity/eclipse/io/FileUtils.java
+++ b/implementation/org.gravity.eclipse/src/org/gravity/eclipse/io/FileUtils.java
@@ -51,7 +51,7 @@ public final class FileUtils {
 			// move the file to a temporary file
 			Files.move(file.toPath(), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 			// print all lines to the original location using system encoding
-			copy(file, tempFile);
+			copy(tempFile, file);
 		} catch (final IOException e) {
 			LOGGER.log(Level.ERROR, "Replacing line endings of file failed: " + e.getMessage(), e);
 			// Try to recover file


### PR DESCRIPTION
In FileUtils.changeToOsEncoding(File file):

Die file Datei wird in tempFile verschoben, danach wird allerdings `copy(file, tempFile)` aufgerufen - er versucht auf die Datei vom alten Ort zuzugreifen statt tempFile als source zu verwenden. Die Parameter müssen getauscht werden.

Hatte den Funktionsaufruf auskommentiert gehabt und vergessen Dienstag zu erwähnen.